### PR TITLE
fix: npx serim-min-cli 실행 에러 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.2",
   "description": "CLI about Serim Min",
   "bin": {
-    "minserim": "dist/cli.js"
+    "minserim": "dist/cli.js",
+    "serim-min-cli": "dist/cli.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
### Description
- `npm install -g serim-min-cli` 는 정상 작동
   - 패키지 설치 후 bin에 정의된 minserim 명령어를 PATH에 등록
   - minserim 실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CLI 명령어 별칭이 추가되었습니다. 새로운 `serim-min-cli` 명령어를 통해 도구를 실행할 수 있으며, 기존 `minserim` 명령어는 계속 사용 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->